### PR TITLE
Introduce cache for rollouts status computation. (#509)

### DIFF
--- a/hawkbit-repository/hawkbit-repository-core/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-core/pom.xml
@@ -25,6 +25,14 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
+         <groupId>com.google.guava</groupId>
+         <artifactId>guava</artifactId>
+      </dependency>      
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-context-support</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.protostuff</groupId>
          <artifactId>protostuff-core</artifactId>
          <optional>true</optional>

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutStatusCache.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutStatusCache.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.hawkbit.cache.TenancyCacheManager;
+import org.eclipse.hawkbit.cache.TenantAwareCacheManager;
+import org.eclipse.hawkbit.repository.event.remote.entity.AbstractActionEvent;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus;
+import org.eclipse.hawkbit.tenancy.TenantAware;
+import org.springframework.cache.Cache;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.context.event.EventListener;
+
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * Internal cache for Rollout status.
+ *
+ */
+public class RolloutStatusCache {
+    private static final String CACHE_RO_NAME = "RolloutStatus";
+    private static final String CACHE_GR_NAME = "RolloutGroupStatus";
+    private static final long DEFAULT_SIZE = 50_000;
+    private final TenancyCacheManager cacheManager;
+    private final TenantAware tenantAware;
+
+    /**
+     * @param tenantAware
+     *            to get current tenant
+     * @param size
+     *            the maximum size of the cache
+     */
+    public RolloutStatusCache(final TenantAware tenantAware, final long size) {
+        this.tenantAware = tenantAware;
+
+        final CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder().maximumSize(size);
+        final GuavaCacheManager guavaCacheManager = new GuavaCacheManager();
+        guavaCacheManager.setCacheBuilder(cacheBuilder);
+
+        this.cacheManager = new TenantAwareCacheManager(guavaCacheManager, tenantAware);
+    }
+
+    /**
+     * @param tenantAware
+     *            to get current tenant
+     */
+    public RolloutStatusCache(final TenantAware tenantAware) {
+        this(tenantAware, DEFAULT_SIZE);
+    }
+
+    /**
+     * Retrieves cached list of {@link TotalTargetCountActionStatus} of
+     * {@link Rollout}s.
+     * 
+     * @param rollouts
+     *            rolloutIds to retrieve cache entries for
+     * @return map of cached entries
+     */
+    public Map<Long, List<TotalTargetCountActionStatus>> getRolloutStatus(final List<Long> rollouts) {
+        final Cache cache = cacheManager.getCache(CACHE_RO_NAME);
+
+        return retrieveFromCache(rollouts, cache);
+    }
+
+    /**
+     * Retrieves cached list of {@link TotalTargetCountActionStatus} of
+     * {@link Rollout}s.
+     * 
+     * @param rolloutId
+     *            to retrieve cache entries for
+     * @return map of cached entries
+     */
+    public List<TotalTargetCountActionStatus> getRolloutStatus(final Long rolloutId) {
+        final Cache cache = cacheManager.getCache(CACHE_RO_NAME);
+
+        return retrieveFromCache(rolloutId, cache);
+    }
+
+    /**
+     * Retrieves cached list of {@link TotalTargetCountActionStatus} of
+     * {@link RolloutGroup}s.
+     * 
+     * @param rolloutGroups
+     *            rolloutGroupsIds to retrieve cache entries for
+     * @return map of cached entries
+     */
+    public Map<Long, List<TotalTargetCountActionStatus>> getRolloutGroupStatus(final List<Long> rolloutGroups) {
+        final Cache cache = cacheManager.getCache(CACHE_GR_NAME);
+
+        return retrieveFromCache(rolloutGroups, cache);
+    }
+
+    /**
+     * Retrieves cached list of {@link TotalTargetCountActionStatus} of
+     * {@link RolloutGroup}.
+     * 
+     * @param groupId
+     *            to retrieve cache entries for
+     * @return map of cached entries
+     */
+    public List<TotalTargetCountActionStatus> getRolloutGroupStatus(final Long groupId) {
+        final Cache cache = cacheManager.getCache(CACHE_GR_NAME);
+
+        return retrieveFromCache(groupId, cache);
+    }
+
+    /**
+     * Put map of {@link TotalTargetCountActionStatus} for multiple
+     * {@link Rollout}s into cache.
+     * 
+     * @param put
+     *            map of cached entries
+     */
+    public void putRolloutStatus(final Map<Long, List<TotalTargetCountActionStatus>> put) {
+        final Cache cache = cacheManager.getCache(CACHE_RO_NAME);
+        putIntoCache(put, cache);
+    }
+
+    /**
+     * Put {@link TotalTargetCountActionStatus} for one {@link Rollout}s into
+     * cache.
+     * 
+     * @param rolloutId
+     *            the cache entries belong to
+     * @param status
+     *            list to cache
+     * 
+     */
+    public void putRolloutStatus(final Long rolloutId, final List<TotalTargetCountActionStatus> status) {
+        final Cache cache = cacheManager.getCache(CACHE_RO_NAME);
+        putIntoCache(rolloutId, status, cache);
+    }
+
+    /**
+     * Put {@link TotalTargetCountActionStatus} for multiple
+     * {@link RolloutGroup}s into cache.
+     * 
+     * @param put
+     *            map of cached entries
+     */
+    public void putRolloutGroupStatus(final Map<Long, List<TotalTargetCountActionStatus>> put) {
+        final Cache cache = cacheManager.getCache(CACHE_GR_NAME);
+        putIntoCache(put, cache);
+    }
+
+    /**
+     * Put {@link TotalTargetCountActionStatus} for multiple
+     * {@link RolloutGroup}s into cache.
+     * 
+     * @param groupId
+     *            the cache entries belong to
+     * @param status
+     *            list to cache
+     */
+    public void putRolloutGroupStatus(final Long groupId, final List<TotalTargetCountActionStatus> status) {
+        final Cache cache = cacheManager.getCache(CACHE_GR_NAME);
+        putIntoCache(groupId, status, cache);
+    }
+
+    private Map<Long, List<TotalTargetCountActionStatus>> retrieveFromCache(final List<Long> ids, final Cache cache) {
+        return ids.stream().map(rolloutId -> cache.get(rolloutId, CachedTotalTargetCountActionStatus.class))
+                .filter(Objects::nonNull).collect(Collectors.toMap(CachedTotalTargetCountActionStatus::getRolloutId,
+                        CachedTotalTargetCountActionStatus::getStatus));
+    }
+
+    private List<TotalTargetCountActionStatus> retrieveFromCache(final Long id, final Cache cache) {
+        final CachedTotalTargetCountActionStatus cacheItem = cache.get(id, CachedTotalTargetCountActionStatus.class);
+
+        if (cacheItem == null) {
+            return Collections.emptyList();
+        }
+
+        return cacheItem.getStatus();
+    }
+
+    private void putIntoCache(final Long rolloutId, final List<TotalTargetCountActionStatus> status,
+            final Cache cache) {
+        cache.put(rolloutId, new CachedTotalTargetCountActionStatus(rolloutId, status));
+    }
+
+    private void putIntoCache(final Map<Long, List<TotalTargetCountActionStatus>> put, final Cache cache) {
+        put.entrySet().forEach(entry -> cache.put(entry.getKey(),
+                new CachedTotalTargetCountActionStatus(entry.getKey(), entry.getValue())));
+    }
+
+    @EventListener(classes = AbstractActionEvent.class)
+    void invalidateCachedTotalTargetCountActionStatus(final AbstractActionEvent event) {
+        if (event.getRolloutId() == null) {
+            return;
+        }
+
+        Cache cache = tenantAware.runAsTenant(event.getTenant(), () -> cacheManager.getCache(CACHE_RO_NAME));
+        cache.evict(event.getRolloutId());
+
+        if (event.getRolloutGroupId() == null) {
+            return;
+        }
+
+        cache = tenantAware.runAsTenant(event.getTenant(), () -> cacheManager.getCache(CACHE_GR_NAME));
+        cache.evict(event.getRolloutGroupId());
+    }
+
+    private static final class CachedTotalTargetCountActionStatus {
+        private final long rolloutId;
+        private final List<TotalTargetCountActionStatus> status;
+
+        private CachedTotalTargetCountActionStatus(final long rolloutId,
+                final List<TotalTargetCountActionStatus> status) {
+            this.rolloutId = rolloutId;
+            this.status = status;
+        }
+
+        public long getRolloutId() {
+            return rolloutId;
+        }
+
+        public List<TotalTargetCountActionStatus> getStatus() {
+            return status;
+        }
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-jpa/pom.xml
@@ -121,7 +121,7 @@
          <plugin>
             <groupId>com.ethlo.persistence.tools</groupId>
             <artifactId>eclipselink-maven-plugin</artifactId>
-            <version>2.6.2</version>
+            <version>2.6.4.2</version>
             <executions>
                <execution>
                   <id>modelgen</id>
@@ -137,6 +137,9 @@
                   </goals>
                </execution>
             </executions>
+            <configuration>
+               <basePackage>org.eclipse.hawkbit.repository.jpa.model</basePackage>
+            </configuration>
             <dependencies>
                <dependency>
                   <groupId>org.eclipse.persistence</groupId>

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -392,7 +392,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            id of {@link Rollout}
      * @return list of objects with status and target count
      */
-    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus( a.rollout.id, a.status , COUNT(a.target)) FROM JpaAction a WHERE a.rollout.id = ?1 GROUP BY a.rollout.id,a.status")
+    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus( a.rollout.id, a.status , COUNT(a.id)) FROM JpaAction a WHERE a.rollout.id = ?1 GROUP BY a.rollout.id,a.status")
     List<TotalTargetCountActionStatus> getStatusCountByRolloutId(Long rolloutId);
 
     /**
@@ -403,7 +403,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            id of {@link RolloutGroup}
      * @return list of objects with status and target count
      */
-    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus(a.rolloutGroup.id, a.status , COUNT(a.target)) FROM JpaAction a WHERE a.rolloutGroup.id = ?1 GROUP BY a.rolloutGroup.id, a.status")
+    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus(a.rolloutGroup.id, a.status , COUNT(a.id)) FROM JpaAction a WHERE a.rolloutGroup.id = ?1 GROUP BY a.rolloutGroup.id, a.status")
     List<TotalTargetCountActionStatus> getStatusCountByRolloutGroupId(Long rolloutGroupId);
 
     /**
@@ -414,7 +414,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            list of id of {@link RolloutGroup}
      * @return list of objects with status and target count
      */
-    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus(a.rolloutGroup.id, a.status , COUNT(a.target)) FROM JpaAction a WHERE a.rolloutGroup.id IN ?1 GROUP BY a.rolloutGroup.id, a.status")
+    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus(a.rolloutGroup.id, a.status , COUNT(a.id)) FROM JpaAction a WHERE a.rolloutGroup.id IN ?1 GROUP BY a.rolloutGroup.id, a.status")
     List<TotalTargetCountActionStatus> getStatusCountByRolloutGroupId(List<Long> rolloutGroupId);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.RolloutGroupFields;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
+import org.eclipse.hawkbit.repository.RolloutStatusCache;
 import org.eclipse.hawkbit.repository.TargetFields;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
@@ -78,6 +79,9 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
 
     @Autowired
     private VirtualPropertyReplacer virtualPropertyReplacer;
+
+    @Autowired
+    private RolloutStatusCache rolloutStatusCache;
 
     @Override
     public Optional<RolloutGroup> findRolloutGroupById(final Long rolloutGroupId) {
@@ -159,8 +163,13 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
 
         final JpaRolloutGroup jpaRolloutGroup = (JpaRolloutGroup) rolloutGroup.get();
 
-        final List<TotalTargetCountActionStatus> rolloutStatusCountItems = actionRepository
-                .getStatusCountByRolloutGroupId(rolloutGroupId);
+        List<TotalTargetCountActionStatus> rolloutStatusCountItems = rolloutStatusCache
+                .getRolloutGroupStatus(rolloutGroupId);
+
+        if (rolloutStatusCountItems.isEmpty()) {
+            rolloutStatusCountItems = actionRepository.getStatusCountByRolloutGroupId(rolloutGroupId);
+            rolloutStatusCache.putRolloutGroupStatus(rolloutGroupId, rolloutStatusCountItems);
+        }
 
         final TotalTargetCountStatus totalTargetCountStatus = new TotalTargetCountStatus(rolloutStatusCountItems,
                 Long.valueOf(jpaRolloutGroup.getTotalTargets()));
@@ -169,11 +178,25 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
 
     }
 
-    private Map<Long, List<TotalTargetCountActionStatus>> getStatusCountItemForRolloutGroup(
-            final List<Long> rolloutGroupIds) {
-        final List<TotalTargetCountActionStatus> resultList = actionRepository
-                .getStatusCountByRolloutGroupId(rolloutGroupIds);
-        return resultList.stream().collect(Collectors.groupingBy(TotalTargetCountActionStatus::getId));
+    private Map<Long, List<TotalTargetCountActionStatus>> getStatusCountItemForRolloutGroup(final List<Long> groupIds) {
+        final Map<Long, List<TotalTargetCountActionStatus>> fromCache = rolloutStatusCache
+                .getRolloutGroupStatus(groupIds);
+
+        final List<Long> rolloutGroupIds = groupIds.stream().filter(id -> !fromCache.containsKey(id))
+                .collect(Collectors.toList());
+
+        if (!rolloutGroupIds.isEmpty()) {
+            final List<TotalTargetCountActionStatus> resultList = actionRepository
+                    .getStatusCountByRolloutGroupId(rolloutGroupIds);
+            final Map<Long, List<TotalTargetCountActionStatus>> fromDb = resultList.stream()
+                    .collect(Collectors.groupingBy(TotalTargetCountActionStatus::getId));
+
+            rolloutStatusCache.putRolloutGroupStatus(fromDb);
+
+            fromCache.putAll(fromDb);
+        }
+
+        return fromCache;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -23,6 +23,7 @@ import org.eclipse.hawkbit.repository.PropertiesQuotaManagement;
 import org.eclipse.hawkbit.repository.RepositoryProperties;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
+import org.eclipse.hawkbit.repository.RolloutStatusCache;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TagManagement;
@@ -130,6 +131,12 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Bean
     PropertiesQuotaManagement staticQuotaManagement(final HawkbitSecurityProperties securityProperties) {
         return new PropertiesQuotaManagement(securityProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    RolloutStatusCache rolloutStatusCache(final TenantAware tenantAware) {
+        return new RolloutStatusCache(tenantAware);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/TestConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/TestConfiguration.java
@@ -22,6 +22,7 @@ import org.eclipse.hawkbit.cache.DefaultDownloadIdCache;
 import org.eclipse.hawkbit.cache.DownloadIdCache;
 import org.eclipse.hawkbit.cache.TenantAwareCacheManager;
 import org.eclipse.hawkbit.event.BusProtoStuffMessageConverter;
+import org.eclipse.hawkbit.repository.RolloutStatusCache;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
 import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
@@ -74,6 +75,14 @@ import org.springframework.util.AntPathMatcher;
 @Profile("test")
 @EnableAutoConfiguration
 public class TestConfiguration implements AsyncConfigurer {
+
+    /**
+     * Disables caching during test to avoid concurrency failures during test.
+     */
+    @Bean
+    RolloutStatusCache rolloutStatusCache(final TenantAware tenantAware) {
+        return new RolloutStatusCache(tenantAware, 0);
+    }
 
     @Bean
     public LockRegistry lockRegistry() {


### PR DESCRIPTION
* Introduce cache for rollouts status computation.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* Disable cache during tests.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* Move cache into core.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* package private event listener.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* Fix cache invalidation.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* Fix sonar issues.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>

* Fixed a test that assumes that target to group assignment follows a rule
which si not the case.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>